### PR TITLE
Use error message of  failed to find a healthy node for karmada-etcd …

### DIFF
--- a/pkg/karmadactl/cmdinit/kubernetes/node.go
+++ b/pkg/karmadactl/cmdinit/kubernetes/node.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -106,6 +107,10 @@ func (i *CommandInitOption) AddNodeSelectorLabels() error {
 			etcdSelectorLabels = v.Labels
 			break
 		}
+	}
+
+	if etcdSelectorLabels == nil {
+		return errors.New("failed to find a healthy node for karmada-etcd")
 	}
 
 	etcdSelectorLabels["karmada.io/etcd"] = ""


### PR DESCRIPTION
…for can not found note to scheduled etcd

Signed-off-by: Lan Liang <gcslyp@gmail.com>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```

